### PR TITLE
[12] - Endpoint users adaptado a laravel

### DIFF
--- a/app/Http/Controllers/UserTaController.php
+++ b/app/Http/Controllers/UserTaController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\UserTa;
+use App\Services\TwitchTokenService;
+use Illuminate\Support\Facades\Http;
+
+class UserTaController extends Controller
+{
+    public function show(Request $request)
+    {
+        $userId = $request->query('id');
+        if (!$userId) {
+            return response()->json(['error' => 'El parámetro "id" no se proporcionó en la URL.'], 400);
+        }
+
+        $user = UserTa::where('twitch_id', $userId)->first();
+
+        if (!$user) {
+            $tokenService = new TwitchTokenService();
+            $token = $tokenService->getTokenFromTwitch();
+
+            if (!$token) {
+                return response()->json(['error' => 'No se pudo obtener el token de acceso desde la base de datos.'], 500);
+            }
+
+            $userData = $this->fetchUserDataFromTwitch($token, $userId);
+
+            if ($userData) {
+                UserTa::create($userData);
+                return response()->json($userData);
+            } else {
+                return response()->json(['error' => 'No se encontraron datos de usuario para el ID proporcionado.'], 404);
+            }
+        }
+
+        return response()->json($user);
+    }
+
+    private function fetchUserDataFromTwitch($token, $userId)
+    {
+        $response = Http::withHeaders([
+            'Authorization' => "Bearer $token",
+            'Client-Id' => env('TWITCH_CLIENT_ID'),
+        ])->get("https://api.twitch.tv/helix/users?id=$userId");
+
+        if ($response->successful()) {
+            $data = $response->json();
+            $user = $data['data'][0] ?? null;
+            if ($user) {
+                return [
+                    'twitch_id' => $user['id'],
+                    'login' => $user['login'],
+                    'display_name' => $user['display_name'],
+                    'type' => $user['type'],
+                    'broadcaster_type' => $user['broadcaster_type'],
+                    'description' => $user['description'],
+                    'profile_image_url' => $user['profile_image_url'],
+                    'offline_image_url' => $user['offline_image_url'],
+                    'view_count' => $user['view_count'],
+                ];
+            }
+        }
+
+        return null;
+    }
+}
+

--- a/app/Models/UserTa.php
+++ b/app/Models/UserTa.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserTa extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'users_ta';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'twitch_id',
+        'login',
+        'display_name',
+        'type',
+        'broadcaster_type',
+        'description',
+        'profile_image_url',
+        'offline_image_url',
+        'view_count',
+    ];
+
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,15 +3,14 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\StreamsController;
+use App\Http\Controllers\UserTaController;
 
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-Route::get('/prueba', function () {
-    return 'pruebanoche';
-});
-
 Route::get('/streams', [StreamsController::class, 'index']);
+
+Route::get('/users', [UserTaController::class, 'show']);
 


### PR DESCRIPTION
Se ha adaptado el endpoint de users para larabel, tambien se guardan los users en la db

Como probarlo: 
- Bajarse la rama 

- cp .env.example .env
- sail up -d
- sail php artisan migration

-http://localhost/api/users?id=1234        <--Cualquier id de twitch vale