### PR TITLE
[18] - Cabeceras correctas json

### DIFF
--- a/app/Http/Controllers/StreamsController.php
+++ b/app/Http/Controllers/StreamsController.php
@@ -34,7 +34,10 @@ class StreamsController extends Controller
 
         $activeStreams = $this->verifyActiveStreams(json_decode($response['body'], true));
 
-        return response()->json($activeStreams);
+        return response()->json($activeStreams)
+            ->setEncodingOptions(JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+
     }
 
     protected function curlPetition($url, $token, $client_id)

--- a/app/Http/Controllers/TopsofthetopsController.php
+++ b/app/Http/Controllers/TopsofthetopsController.php
@@ -26,6 +26,6 @@ class TopsofthetopsController extends Controller
 
         return response()->json([
             'data' => $topOfTheTopsData
-        ])->setEncodingOptions(JSON_PRETTY_PRINT);
+        ])->setEncodingOptions(JSON_PRETTY_PRINT| JSON_UNESCAPED_UNICODE);
     }
 }

--- a/app/Http/Controllers/UserTaController.php
+++ b/app/Http/Controllers/UserTaController.php
@@ -30,13 +30,13 @@ class UserTaController extends Controller
 
             if ($userData) {
                 UserTa::create($userData);
-                return response()->json($userData);
+                return response()->json($userData)->setEncodingOptions(JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
             } else {
                 return response()->json(['error' => 'No se encontraron datos de usuario para el ID proporcionado.'], 404);
             }
         }
 
-        return response()->json($user);
+        return response()->json($user)->setEncodingOptions(JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
     private function fetchUserDataFromTwitch($token, $userId)

--- a/app/Services/TopGamesService.php
+++ b/app/Services/TopGamesService.php
@@ -21,7 +21,7 @@ class TopGamesService
             throw new \Exception("No se pudo obtener el token de Twitch.");
         }
 
-        $url = 'https://api.twitch.tv/helix/games/top?first=3'; // Ajusta el parámetro 'first' según necesites
+        $url = 'https://api.twitch.tv/helix/games/top?first=3';
         $response = Http::withHeaders([
             'Authorization' => "Bearer {$accessToken}",
             'Client-Id' => env('TWITCH_CLIENT_ID'),
@@ -33,12 +33,12 @@ class TopGamesService
             throw new \Exception("No se encontraron datos válidos en la respuesta de la API de Twitch.");
         }
 
-        // Vaciar la tabla topGames antes de insertar los nuevos datos
+
         TopGame::truncate();
 
         foreach ($games as $game) {
             TopGame::create([
-                'game_id' => $game['id'], // Asegúrate de que tu modelo TopGame y la migración correspondiente estén configurados para aceptar este campo
+                'game_id' => $game['id'],
                 'game_name' => $game['name'],
             ]);
         }

--- a/app/Services/TopsofthetopsService.php
+++ b/app/Services/TopsofthetopsService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use App\Models\TopGame;
 use App\Models\TopOfTheTop;
 use App\Models\TopVideo;
-use Illuminate\Support\Facades\Http;
 use Carbon\Carbon;
 
 class TopsofthetopsService

--- a/app/Services/TwitchTokenService.php
+++ b/app/Services/TwitchTokenService.php
@@ -33,7 +33,7 @@ class TwitchTokenService
             throw new \Exception("Error al solicitar el token.");
         }
 
-        $tokenModel = Token::find(1); // Asume que el ID del token que quieres actualizar es 1
+        $tokenModel = Token::find(1);
         if ($tokenModel) {
             $tokenModel->access_token = $newToken;
             $tokenModel->save();


### PR DESCRIPTION
Se han cambiado las cabeceras para que los JSON se devuelvan de manera estética para visualizarlos en navegadores.

Como probarlo:

- Utilizar cualquier link del readme en tu navegador favorito

